### PR TITLE
Corrigir erro de container e limpar arquivos do cliente

### DIFF
--- a/interface/login.py
+++ b/interface/login.py
@@ -213,12 +213,22 @@ class LoginWindow:
                 
                 messagebox.showinfo("Sucesso", f"Bem-vindo, {nome_completo}!")
                 
-                # Fechar login
-                self.login_window.destroy()
+                # Tentar abrir a janela principal; só destruir o login após sucesso
+                try:
+                    self.abrir_sistema_principal(user_id, role, nome_completo)
+                except Exception as e:
+                    # Em caso de falha ao abrir o sistema, manter a janela de login e exibir erro
+                    if self.status_label and self.status_label.winfo_exists():
+                        self.status_label.config(text="❌ Erro ao abrir o sistema", fg='#ef4444')
+                    messagebox.showerror("Erro", f"Erro ao abrir o sistema: {e}")
+                    return
                 
-                # Abrir sistema principal
-                self.abrir_sistema_principal(user_id, role, nome_completo)
+                # Se chegou aqui, o sistema abriu com sucesso: destruir janela de login
+                if self.login_window and self.login_window.winfo_exists():
+                    self.login_window.destroy()
                 
+                # Encerrar processamento após sucesso
+                return
             else:
                 self.status_label.config(text="❌ Usuário ou senha incorretos!", fg='#ef4444')
                 messagebox.showerror("Erro", "Usuário ou senha incorretos!")


### PR DESCRIPTION
Fixes TclError by safely destroying login window and removes unused screenshot files.

The `TclError` occurred because the login window was destroyed before the main application window was fully initialized, leading to attempts to update non-existent widgets. The fix ensures the login window is only destroyed after the main window is successfully opened. Unused screenshot files were removed as they were debug artifacts.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b363299-f721-41d7-8795-b7ce1ffebd6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b363299-f721-41d7-8795-b7ce1ffebd6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

