### PR TITLE
Debug location save error: 17 values for 18 columns

### DIFF
--- a/interface/modules/locacao.py
+++ b/interface/modules/locacao.py
@@ -407,7 +407,7 @@ class LocacaoModule(BaseModule):
                     data_inicio, data_fim, marca, modelo, numero_serie,
                     valor_mensal, moeda, vencimento_dia, condicoes_pagamento,
                     imagem_compressor, apresentacao_texto, prezados_linha, equipamento_titulo, itens_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 dados['numero'], dados['cliente_id'], dados['filial_id'], dados['responsavel_id'],
                 dados.get('data_inicio') or None, dados.get('data_fim') or None, dados['marca'], dados['modelo'], dados['serie'],


### PR DESCRIPTION
Add a missing placeholder in the `INSERT` statement for locações to resolve the "17 values for 18 columns" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-34e5b1fa-b9d3-456c-84ef-0384e6cbf087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34e5b1fa-b9d3-456c-84ef-0384e6cbf087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

