### PR TITLE
Debug import error in crm system

### DIFF
--- a/interface/modules/__init__.py
+++ b/interface/modules/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     'DashboardModule',
     'ClientesModule',
     'ProdutosModule',
-        'CotacoesModule',
+    'CotacoesModule',
     'RelatoriosModule',
     'UsuariosModule',
     'PermissoesModule',

--- a/interface/modules/cotacoes_backup.py
+++ b/interface/modules/cotacoes_backup.py
@@ -1562,20 +1562,20 @@ class CotacoesModule(BaseModule):
 			if cotacao[20]:
 				self.relacao_pecas_text.insert("1.0", cotacao[20])
 			
-					# Campos de Locação
-		self.tipo_cotacao_var.set(cotacao[21] or "Compra")
-		self.locacao_valor_mensal_var.set(f"{cotacao[22]:.2f}" if cotacao[22] is not None else "0.00")
-		self.locacao_data_inicio_var.set(format_date(cotacao[23]) if cotacao[23] else "")
-		self.locacao_data_fim_var.set(format_date(cotacao[24]) if cotacao[24] else "")
-		self.locacao_qtd_meses_var.set(str(cotacao[25] or 0))
-		self.locacao_equipamento_var.set(cotacao[26] or "")
-		
-		# Recarregar caminho da imagem se existir
-		try:
-			self.locacao_imagem_var.set(cotacao[27] or "")
-		except Exception:
-			pass
+			# Campos de Locação
+			self.tipo_cotacao_var.set(cotacao[21] or "Compra")
+			self.locacao_valor_mensal_var.set(f"{cotacao[22]:.2f}" if cotacao[22] is not None else "0.00")
+			self.locacao_data_inicio_var.set(format_date(cotacao[23]) if cotacao[23] else "")
+			self.locacao_data_fim_var.set(format_date(cotacao[24]) if cotacao[24] else "")
+			self.locacao_qtd_meses_var.set(str(cotacao[25] or 0))
+			self.locacao_equipamento_var.set(cotacao[26] or "")
 			
+			# Recarregar caminho da imagem se existir
+			try:
+				self.locacao_imagem_var.set(cotacao[27] or "")
+			except Exception:
+				pass
+				
 			# Alternar UI conforme tipo de cotação
 			self.on_tipo_cotacao_changed()
 			


### PR DESCRIPTION
Fix indentation errors in `__init__.py` and `cotacoes_backup.py` to resolve import issues and allow the application to start.

The application was failing to start with an `ImportError` for `CotacoesModule`. This was caused by two distinct indentation errors:
1.  A block of code in `cotacoes_backup.py` was incorrectly outside its `try` block, causing a syntax error.
2.  The `'CotacoesModule'` entry in `__init__.py`'s `__all__` list had incorrect indentation.
Both issues have been corrected, allowing the modules to be imported successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-b29df42b-753c-4a6d-92c5-75c499f60d11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b29df42b-753c-4a6d-92c5-75c499f60d11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

